### PR TITLE
Refactored the Event Models and Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ coverage.txt
 *.test
 *.prof
 *.swp
+*.swo

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,9 @@ lint: ## Runs linting
 		--enable=structcheck \
 		--enable=unconvert \
 		--skip=generated \
-		--skip=go\
+		--skip=go \
+		--deadline=3m \
+		--concurrency=2 \
 		./...
 
 .PHONY: generate-contracts

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/joincivil/civil-events-crawler
 require (
 	github.com/aristanetworks/goarista v0.0.0-20180524035941-59652c8de980
 	github.com/ethereum/go-ethereum v1.8.8
+	github.com/fatih/structs v1.0.0
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db
 	github.com/pborman/uuid v0.0.0-20180122190007-c65b2f87fee3
 	github.com/rjeczalik/notify v0.0.0-20180312213058-d152f3ce359a


### PR DESCRIPTION
I have a PR coming up for the listener piece and this came up while working on that PR.

- Refactored the `CivilEvent` model a little bit to wrap around `github.com/fatih/structs/`, which gives us more flexibility when ingesting the Civil contract event structs and accessing the event fields.  The code seems a bit cleaner as well.
- Updated the model tests.
- Added some libs for `structs` and `glog` and some adjustments for `make test`.

