### PR TITLE
Added gometalinter Vendor=true to Config

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -14,6 +14,7 @@
         "errcheck",
         "staticcheck"
     ],
+    "Vendor": true,
     "Concurrency": 2,
     "Skip": [
         "go",


### PR DESCRIPTION
- Missing flag to skip the "/vendor/" directory when linting.