### PR TITLE
Time Utils Cleanup; Int64 Timestamp Function

### DIFF
--- a/pkg/utils/time.go
+++ b/pkg/utils/time.go
@@ -13,8 +13,14 @@ func CurrentEpochSecsInFloat() float64 {
 	return ts
 }
 
+// CurrentEpochSecsInInt64 returns the current time as a timestamp
+// from epoch as type int64 in seconds.
+func CurrentEpochSecsInInt64() int64 {
+	return time.Now().Unix()
+}
+
 // CurrentEpochSecsInInt returns the current time as a timestamp
-// from epoch as type float64 in seconds.
+// from epoch as type int in seconds.
 func CurrentEpochSecsInInt() int {
-	return int(CurrentEpochSecsInFloat())
+	return int(CurrentEpochSecsInInt64())
 }

--- a/pkg/utils/time_test.go
+++ b/pkg/utils/time_test.go
@@ -4,12 +4,34 @@ package utils_test
 import (
 	"github.com/joincivil/civil-events-crawler/pkg/utils"
 	"testing"
+	"time"
 )
+
+var EPSILON float64 = 0.999
+
+func floatEquals(a float64, b float64) bool {
+	return (a-b) < EPSILON && (b-a) < EPSILON
+}
 
 func TestCurrentEpochSecsInFloat(t *testing.T) {
 	ts := utils.CurrentEpochSecsInFloat()
 	if ts <= 0.0 {
 		t.Error("Timestamp is <= 0.0, it should be greater than 0")
+	}
+	now := time.Now()
+	if !floatEquals(ts, float64(now.Unix())) {
+		t.Error("Float timestamp is not equivalent to the calculated timestamp")
+	}
+}
+
+func TestCurrentEpochSecsInInt64(t *testing.T) {
+	ts := utils.CurrentEpochSecsInInt64()
+	if ts <= 0 {
+		t.Error("Timestamp is <= 0, it should be greater than 0")
+	}
+	now := time.Now()
+	if now.Unix() != int64(ts) {
+		t.Error("Int64 timestamp is not equal to the calculated timestamp")
 	}
 }
 
@@ -17,5 +39,9 @@ func TestCurrentEpochSecsInInt(t *testing.T) {
 	ts := utils.CurrentEpochSecsInInt()
 	if ts <= 0 {
 		t.Error("Timestamp is <= 0, it should be greater than 0")
+	}
+	now := time.Now()
+	if int(now.Unix()) != ts {
+		t.Error("Int timestamp is not equal to the calculated timestamp")
 	}
 }


### PR DESCRIPTION
- Cleaned up the `int` timestamp functions, returns from the `time.Unix()` call rather than casting from `float64`.  
- Added an `int64` timestamp function.  Can slowly replace the normal `int` precision versions with `int64` if needed.
- Added some better testing to ensure values from the timestamp functions are what we expect.