### PR TITLE
Removed Vendor Caching from Crawler CI Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,20 +26,10 @@ jobs:
               echo sudo > ~/sudo
             fi
       - checkout
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "Gopkg.lock" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
       - setup_remote_docker:   # (2)
           docker_layer_caching: true # (3)
 
       - run: make setup
-
-      - save_cache:
-          paths:
-            - vendor
-          key: v1-dependencies-{{ checksum "Gopkg.lock" }}
 
       - run:
           name: Waiting for Postgres to be ready


### PR DESCRIPTION
While I was creating the processor CI config, noticed that we are caching the `/vendor` directory without actually running a `dep ensure` and we fallback to a default key for the cache. So old vendor data was being used, but not being updated to be recached. Since the vendor directory is checked out anyway, there is no need to cached `/vendor` since we have already checked it out.