### PR TITLE
Add Support for an Ignored DB Field using StructFieldsForQuery

### DIFF
--- a/pkg/persistence/postgres/utils.go
+++ b/pkg/persistence/postgres/utils.go
@@ -7,6 +7,13 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
+)
+
+const (
+	// If this is the field name in a struct db tag, it should be ignored
+	// ex. `db:"-"`
+	ignoredFieldName = "-"
 )
 
 // JsonbPayload is the jsonb payload
@@ -46,6 +53,10 @@ func StructFieldsForQuery(exampleStruct interface{}, colon bool) (string, string
 	typeOf := valStruct.Type()
 	for i := 0; i < valStruct.NumField(); i++ {
 		dbFieldName := typeOf.Field(i).Tag.Get("db")
+		// Skip ignored fields
+		if strings.TrimSpace(dbFieldName) == ignoredFieldName {
+			continue
+		}
 		fields.WriteString(dbFieldName) // nolint: gosec
 		if colon {
 			fieldsWithColon.WriteString(":")         // nolint: gosec
@@ -58,7 +69,8 @@ func StructFieldsForQuery(exampleStruct interface{}, colon bool) (string, string
 			}
 		}
 	}
-	return fields.String(), fieldsWithColon.String()
+	return strings.Trim(fields.String(), ", "),
+		strings.Trim(fieldsWithColon.String(), ", ")
 }
 
 // InsertIntoDBQueryString creates the query to insert a given struct into a given table

--- a/pkg/persistence/postgres/utils_test.go
+++ b/pkg/persistence/postgres/utils_test.go
@@ -1,0 +1,44 @@
+package postgres_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/joincivil/civil-events-crawler/pkg/persistence/postgres"
+)
+
+type testStruct struct {
+	field1        string `db:"field1"` // nolint: megacheck
+	field2        int    `db:"field2"` // nolint: megacheck
+	field4Ignored string `db:"-"`      // nolint: megacheck
+	field4        int    `db:"field4"` // nolint: megacheck
+	field5Ignored bool   `db:"-"`      // nolint: megacheck
+}
+
+func TestStructFieldsForQuery(t *testing.T) {
+	fieldNames, fieldNamesColon := postgres.StructFieldsForQuery(testStruct{}, true)
+
+	splitFields := strings.Split(fieldNames, ",")
+	if len(splitFields) != 3 {
+		t.Errorf("Should have only returned 3 fields, not %v", len(splitFields))
+	}
+	for _, fieldName := range splitFields {
+		fieldName = strings.TrimSpace(fieldName)
+		if fieldName == "-" {
+			t.Error("Should have not had '-' field in fields")
+			break
+		}
+	}
+
+	splitFieldsColon := strings.Split(fieldNamesColon, ",")
+	if len(splitFieldsColon) != 3 {
+		t.Errorf("Should have only returned 3 fields, not %v", len(splitFieldsColon))
+	}
+	for _, fieldName := range splitFieldsColon {
+		fieldName = strings.TrimSpace(fieldName)
+		if fieldName == ":-" {
+			t.Error("Should have not had ':-' field in fields")
+			break
+		}
+	}
+}


### PR DESCRIPTION
- Allows for a struct to have a db tag "-", which means to ignore the field when running through `StructFieldsForQuery`
- Adds some tests for `StructFieldsForQuery`