### PR TITLE
Adding "trigger" for Filterer to add Newsrooms

### DIFF
--- a/pkg/eventcollector/eventcollector.go
+++ b/pkg/eventcollector/eventcollector.go
@@ -58,7 +58,7 @@ type EventCollector struct {
 
 	triggers []Trigger
 
-	filterTriggers []model.ContractFilterers
+	additionalNewsroomFilterers []model.ContractFilterers
 
 	filterers []model.ContractFilterers
 
@@ -137,9 +137,9 @@ func (c *EventCollector) StartCollection() error {
 	if err != nil {
 		return fmt.Errorf("Error checking newsroom events during filterer, err: %v", err)
 	}
-	if len(c.filterTriggers) > 0 {
+	if len(c.additionalNewsroomFilterers) > 0 {
 		// NOTE(IS): This overwrites the previous retriever with the new filterers
-		err = c.retrieveEvents(c.filterTriggers)
+		err = c.retrieveEvents(c.additionalNewsroomFilterers)
 		if err != nil {
 			return fmt.Errorf("Error retrieving new Newsroom events: err: %v", err)
 		}
@@ -322,7 +322,7 @@ func (c *EventCollector) CheckRetrievedEventsForNewsroom(pastEvents []*model.Eve
 			}
 			if _, ok := existingFiltererNewsroomAddr[newsroomAddr]; !ok {
 				newFilterer := filterer.NewNewsroomContractFilterers(newsroomAddr)
-				c.filterTriggers = append(c.filterTriggers, newFilterer)
+				c.additionalNewsroomFilterers = append(c.additionalNewsroomFilterers, newFilterer)
 			}
 			if _, ok := existingWatcherNewsroomAddr[newsroomAddr]; !ok {
 				newWatcher := watcher.NewNewsroomContractWatchers(newsroomAddr)

--- a/pkg/eventcollector/eventcollector_test.go
+++ b/pkg/eventcollector/eventcollector_test.go
@@ -17,6 +17,7 @@ import (
 
 	cutils "github.com/joincivil/civil-events-crawler/pkg/contractutils"
 	"github.com/joincivil/civil-events-crawler/pkg/eventcollector"
+	"github.com/joincivil/civil-events-crawler/pkg/generated/contract"
 	"github.com/joincivil/civil-events-crawler/pkg/generated/filterer"
 	"github.com/joincivil/civil-events-crawler/pkg/generated/watcher"
 	"github.com/joincivil/civil-events-crawler/pkg/model"
@@ -472,4 +473,45 @@ func TestNewEventCollectorBadUpdateBlockData(t *testing.T) {
 		t.Errorf("Application failed: err: %v", err)
 	}
 	contracts.Client.Commit()
+}
+
+func TestCheckRetrievedEventsForNewsroom(t *testing.T) {
+	contracts, err := cutils.SetupAllTestContracts()
+	if err != nil {
+		t.Fatalf("Unable to setup the contracts: %v", err)
+	}
+	collector, _ := setupTestCollectorTestPersisterBadUpdateBlockData(contracts)
+
+	testAddress := "0xdfe273082089bb7f70ee36eebcde64832fe97e55"
+	testApplicationWhitelisted := &contract.CivilTCRContractApplicationWhitelisted{
+		ListingAddress: common.HexToAddress(testAddress),
+		Raw: types.Log{
+			Address:     common.HexToAddress(testAddress),
+			Topics:      []common.Hash{},
+			Data:        []byte{},
+			BlockNumber: 8888888,
+			Index:       1,
+		},
+	}
+	testListingRemoved := &contract.CivilTCRContractApplicationRemoved{
+		ListingAddress: common.HexToAddress(testAddress),
+		Raw: types.Log{
+			Address:     common.HexToAddress(testAddress),
+			Topics:      []common.Hash{},
+			Data:        []byte{},
+			BlockNumber: 8888888,
+			Index:       1,
+		},
+	}
+	event1, _ := model.NewEventFromContractEvent("ApplicationWhitelisted", "CivilTCRContract", common.HexToAddress(testAddress),
+		testApplicationWhitelisted, 0, model.Watcher)
+	event2, _ := model.NewEventFromContractEvent("ListingRemoved", "CivilTCRContract", common.HexToAddress(testAddress),
+		testListingRemoved, 0, model.Watcher)
+	pastEvents := []*model.Event{event1, event2}
+
+	err = collector.CheckRetrievedEventsForNewsroom(pastEvents)
+	if err != nil {
+		t.Errorf("Error checking retrieved events: %v", err)
+	}
+
 }

--- a/pkg/eventcollector/eventcollector_test.go
+++ b/pkg/eventcollector/eventcollector_test.go
@@ -509,7 +509,7 @@ func TestCheckRetrievedEventsForNewsroom(t *testing.T) {
 		testListingRemoved, 0, model.Watcher)
 	pastEvents := []*model.Event{event1, event2}
 
-	err = collector.CheckRetrievedEventsForNewsroom(pastEvents)
+	_, err = collector.CheckRetrievedEventsForNewsroom(pastEvents)
 	if err != nil {
 		t.Errorf("Error checking retrieved events: %v", err)
 	}

--- a/pkg/eventcollector/triggers.go
+++ b/pkg/eventcollector/triggers.go
@@ -7,6 +7,7 @@ import (
 
 	log "github.com/golang/glog"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/joincivil/civil-events-crawler/pkg/generated/watcher"
 	"github.com/joincivil/civil-events-crawler/pkg/model"
 )
@@ -25,7 +26,7 @@ func (n *AddNewsroomWatchersTrigger) Description() string {
 // ShouldRun returns true or false on whether this trigger should be run
 func (n *AddNewsroomWatchersTrigger) ShouldRun(collector *EventCollector,
 	event *model.Event) bool {
-	return event.EventType() == "_ApplicationWhiteListed"
+	return event.EventType() == "ApplicationWhiteListed"
 }
 
 // Run returns the triggered code
@@ -34,7 +35,7 @@ func (n *AddNewsroomWatchersTrigger) Run(collector *EventCollector,
 	if !n.ShouldRun(collector, event) {
 		return errors.New("AddNewsroomWatchersTrigger should not run")
 	}
-	newsroomAddr := event.LogPayload().Address
+	newsroomAddr := event.EventPayload()["ListingAddress"].(common.Address)
 	err := collector.AddWatchers(
 		watcher.NewNewsroomContractWatchers(newsroomAddr),
 	)
@@ -57,7 +58,7 @@ func (n *RemoveNewsroomWatchersTrigger) Description() string {
 // ShouldRun returns true or false on whether this trigger should be run
 func (n *RemoveNewsroomWatchersTrigger) ShouldRun(collector *EventCollector,
 	event *model.Event) bool {
-	return event.EventType() == "_ListingRemoved"
+	return event.EventType() == "ListingRemoved"
 }
 
 // Run returns the triggered code
@@ -66,7 +67,7 @@ func (n *RemoveNewsroomWatchersTrigger) Run(collector *EventCollector,
 	if !n.ShouldRun(collector, event) {
 		return errors.New("RemoveNewsroomWatchersTriggershould not run")
 	}
-	newsroomAddr := event.LogPayload().Address
+	newsroomAddr := event.EventPayload()["ListingAddress"].(common.Address)
 	err := collector.RemoveWatchers(
 		watcher.NewNewsroomContractWatchers(newsroomAddr),
 	)


### PR DESCRIPTION
- Fix problem where we won't get any newsrooms if we start tracking a TCR after it's been up and running with newsrooms for a while. For this, I added an extra step after filterer first finishes running. It may not be the most ideal but something I came up with given the time constraints.

- Fixed some errors in current watcher triggers that was causing them probably not to trigger? (It seems that the application name and listing address was wrong)