### PR TITLE
Simple Function to Normalize Eth Hex Address Strings

### DIFF
--- a/pkg/utils/eth.go
+++ b/pkg/utils/eth.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -45,4 +46,12 @@ func (b *BlockHeaderCache) AddHeader(num uint64, header *types.Header) {
 		addedTs: CurrentEpochSecsInInt64(),
 		header:  header,
 	}
+}
+
+// NormalizeEthAddress takes a string address to normalize the
+// case of the ethereum address when it is a string.
+// Runs through common.Address.Hex().
+func NormalizeEthAddress(addr string) string {
+	address := common.HexToAddress(addr)
+	return address.Hex()
 }

--- a/pkg/utils/eth_test.go
+++ b/pkg/utils/eth_test.go
@@ -41,3 +41,21 @@ func TestBlockHeaderCache(t *testing.T) {
 		t.Error("Should have not retrieved a header after duration")
 	}
 }
+
+func TestNormalizeEthAddress(t *testing.T) {
+	addr1 := "0x39eD84CE90Bc48DD76C4760DD0F90997Ba274F9d"
+	addr2 := "0x39ed84ce90bc48dd76c4760dd0f90997ba274f9d"
+
+	normalized1 := utils.NormalizeEthAddress(addr1)
+	normalized2 := utils.NormalizeEthAddress(addr2)
+
+	if normalized1 == "" {
+		t.Errorf("Should have converted address correctly")
+	}
+	if normalized2 == "" {
+		t.Errorf("Should have converted address correctly")
+	}
+	if normalized1 != normalized2 {
+		t.Errorf("Addresses should have matched")
+	}
+}


### PR DESCRIPTION
- Putting it here in crawler for reuse amongst all the components
- For use to normalize addresses when we store or query for them.