### PR TITLE
Enable Index Creation on Crawler Startup

### DIFF
--- a/cmd/crawler/main.go
+++ b/cmd/crawler/main.go
@@ -74,6 +74,12 @@ func postgresPersister(config *utils.CrawlerConfig) *persistence.PostgresPersist
 		log.Errorf("Error creating tables, stopping...; err: %v", err)
 		os.Exit(1)
 	}
+	// Attempts to create all the necessary indices on the tables
+	err = persister.CreateIndices()
+	if err != nil {
+		log.Errorf("Error creating indices, stopping...; err: %v", err)
+		os.Exit(1)
+	}
 	// Populate persistence with latest block data from events table
 	err = persister.PopulateBlockDataFromDB("event")
 	if err != nil {


### PR DESCRIPTION
- Enables the table index creation on crawler startup
    - Should be measured in how we push out new indices later depending on the table size at that time, but I feel like we are going to forget to add these whenever the tables get turned over.

[ch2326]