### PR TITLE
Returning events in order of ID by default in retrieveEvents

### DIFF
--- a/pkg/model/persistinterfaces.go
+++ b/pkg/model/persistinterfaces.go
@@ -38,8 +38,9 @@ type RetrieverMetaDataPersister interface {
 // RetrieveEventsCriteria contains the retrieval criteria for a RetrieveEvents
 // query.
 type RetrieveEventsCriteria struct {
-	Offset    int    `db:"offset"`
-	Count     int    `db:"count"`
+	Offset int `db:"offset"`
+	Count  int `db:"count"`
+	// Reverse reverses by id in DB
 	Reverse   bool   `db:"reverse"`
 	FromTs    int64  `db:"fromts"`
 	BeforeTs  int64  `db:"beforets"`

--- a/pkg/persistence/postgrespersister.go
+++ b/pkg/persistence/postgrespersister.go
@@ -169,7 +169,7 @@ func (p *PostgresPersister) retrieveEventsQuery(tableName string, criteria *mode
 		queryBuf.WriteString(" event_type = :eventtype") // nolint: gosec
 	}
 	if criteria.Reverse {
-		queryBuf.WriteString(" ORDER BY timestamp DESC") // nolint: gosec
+		queryBuf.WriteString(" ORDER BY id DESC") // nolint: gosec
 	} else {
 		queryBuf.WriteString(" ORDER BY id") // nolint: gosec
 	}

--- a/pkg/persistence/postgrespersister.go
+++ b/pkg/persistence/postgrespersister.go
@@ -170,6 +170,8 @@ func (p *PostgresPersister) retrieveEventsQuery(tableName string, criteria *mode
 	}
 	if criteria.Reverse {
 		queryBuf.WriteString(" ORDER BY timestamp DESC") // nolint: gosec
+	} else {
+		queryBuf.WriteString(" ORDER BY id") // nolint: gosec
 	}
 	if criteria.Offset > 0 {
 		queryBuf.WriteString(" OFFSET :offset") // nolint: gosec

--- a/pkg/persistence/postgrespersister_test.go
+++ b/pkg/persistence/postgrespersister_test.go
@@ -1017,6 +1017,27 @@ func TestRetrieveEvents(t *testing.T) {
 	}
 
 	events, err = persister.retrieveEventsFromTable(eventTestTableName, &model.RetrieveEventsCriteria{
+		Offset:  0,
+		Count:   3,
+		Reverse: false,
+	})
+	if err != nil {
+		t.Errorf("Should not have received error when retrieving events: err: %v", err)
+	}
+	if len(events) != 3 {
+		t.Errorf("Should have seen only 2 event: %v", len(events))
+	}
+	if events[0].Hash() != civilEventsFromContract[0].Hash() {
+		t.Errorf("Should have seen the type of the most recent event: err: %v", err)
+	}
+	if events[1].Hash() != civilEventsFromContract[1].Hash() {
+		t.Errorf("Should have seen the type of the most recent event: err: %v", err)
+	}
+	if events[2].Hash() != civilEventsFromContract[2].Hash() {
+		t.Errorf("Should have seen the type of the most recent event: err: %v", err)
+	}
+
+	events, err = persister.retrieveEventsFromTable(eventTestTableName, &model.RetrieveEventsCriteria{
 		Offset:    0,
 		Count:     10,
 		EventType: "Application",


### PR DESCRIPTION
- If reverse is not specified, return events in order by id

[ch2664]