### PR TITLE
Ping for WS connections & Refactoring

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -12,7 +12,9 @@
         "unconvert",
         "gosec",
         "errcheck",
-        "staticcheck"
+        "staticcheck",
+        "ineffassign",
+        "misspell"
     ],
     "Vendor": true,
     "Concurrency": 2,

--- a/pkg/contractutils/contractutils.go
+++ b/pkg/contractutils/contractutils.go
@@ -267,7 +267,7 @@ func setupTestEIP20Contract(client bind.ContractBackend, auth *bind.TransactOpts
 // with the actual addresses to those library contracts
 func modifyByteCodeWithDllAttrStore(bin string, dllAddr common.Address,
 	attrStoreAddr common.Address) string {
-	// To add the DLL and AttributeStore addresses, replace occurrances of
+	// To add the DLL and AttributeStore addresses, replace occurrences of
 	// _DLL__________ and _AttributeStore__________ with the respective contract addresses
 	ddlRexp := regexp.MustCompile("_+DLL_+")
 	asRexp := regexp.MustCompile("_+AttributeStore_+")

--- a/pkg/model/event.go
+++ b/pkg/model/event.go
@@ -28,18 +28,18 @@ const (
 // RetrievalMethod is the enum for the type of retrieval method
 type RetrievalMethod int
 
-// ReturnEventsFromABI returns abi.Event struct from the ABI
-func ReturnEventsFromABI(_abi abi.ABI, eventType string) (abi.Event, error) {
+// ReturnEventFromABI returns abi.Event struct from the ABI
+func ReturnEventFromABI(_abi abi.ABI, eventType string) (abi.Event, error) {
 	// Some contracts have an underscore prefix on their events. Handle both
 	// non-underscore/underscore cases here.
-	events, ok := _abi.Events[eventType]
+	event, ok := _abi.Events[eventType]
 	if !ok {
-		events, ok = _abi.Events[fmt.Sprintf("_%s", eventType)]
+		event, ok = _abi.Events[fmt.Sprintf("_%s", eventType)]
 		if !ok {
-			return events, fmt.Errorf("No event type %v in contract", eventType)
+			return abi.Event{}, fmt.Errorf("No event type %v in contract", eventType)
 		}
 	}
-	return events, nil
+	return event, nil
 }
 
 // NewEventFromContractEvent creates a new event after converting eventData to interface{}
@@ -117,12 +117,12 @@ func extractFieldsFromEvent(payload *EventPayload, eventData interface{}, eventT
 		return eventPayload, err
 	}
 
-	events, err := ReturnEventsFromABI(_abi, eventType)
+	abiEvent, err := ReturnEventFromABI(_abi, eventType)
 	if err != nil {
 		return eventPayload, err
 	}
 
-	for _, input := range events.Inputs {
+	for _, input := range abiEvent.Inputs {
 		eventFieldName := strings.Title(input.Name)
 		eventField, ok := payload.Value(eventFieldName)
 		if !ok {

--- a/pkg/persistence/postgres/event_test.go
+++ b/pkg/persistence/postgres/event_test.go
@@ -30,7 +30,7 @@ var (
 				common.HexToHash("0x0000000000000000000000002652c60cf04bbf6bb6cc8a5e6f1c18143729d440"),
 				common.HexToHash("0x00000000000000000000000025bf9a1595d6f6c70e6848b60cba2063e4d9e552"),
 			},
-			Data:        []byte{},
+			Data:        []byte("thisisadatastring"),
 			BlockNumber: 8888888,
 			TxHash:      common.Hash{},
 			TxIndex:     2,

--- a/pkg/persistence/postgrespersister.go
+++ b/pkg/persistence/postgrespersister.go
@@ -189,7 +189,7 @@ func (p *PostgresPersister) saveEventToTable(query string, event *model.Event) e
 	}
 	_, err = p.db.NamedExec(query, dbEvent)
 	if err != nil {
-		return fmt.Errorf("Error saving event to table %v", err)
+		return fmt.Errorf("Error saving event to table: err %v: event: %T", err, dbEvent.LogPayload["Data"])
 	}
 	return nil
 }


### PR DESCRIPTION
Originally work for add a "ping" for WS connections, sort of snowballed into a bit of refactoring and cleanup.  Apologies in advance for the hodge-podge in a large PR, but they (mostly) relate to each other.

**Fixes & Additions:**
* Ping for WS connections to ensure they keep alive during points there there is not a lot of activity.
* Fixed a closed channel issue on `quitChan`.

**Refactoring:**
* Created an `EventCollector` Config params struct to pass into `EventCollector`.
* Added some code to allow us to disable the listener on crawler startup, mainly in the case that don't have a websocket connection to the eth node.
* Cleaned up some stuff in `EventCollector`, separated the "run retriever" from the "start listener" into different methods.  This was for cleanup and readability.
* Added a "started signal" for the `EventCollector` to signal when it was completely started up.  Allows for more accurate testing (don't need time.Sleep) and could be used to ensure proper startup before proceeding.
* Cleaned up some confusing plurality naming.
* Noticed there were two `deleteTestTable` calls in multiple test functions (one deferred and one not deferred).  Consolidated into one deferred function.
* Added some additional tests to gometalinter config.

**Also, will handle the merge of the processor refactor into this, since these are happening at the same time.  Will merge in those changes and update before merging this branch.**