### PR TITLE
Debugging "fails to save event" Issue

### DIFF
--- a/pkg/eventcollector/triggers.go
+++ b/pkg/eventcollector/triggers.go
@@ -42,7 +42,7 @@ func (n *AddNewsroomWatchersTrigger) Run(collector *EventCollector,
 	if err != nil {
 		return fmt.Errorf("Error adding watchers: err: %v", err)
 	}
-	log.Infof("Adding watchers for newsroom at address: %v", newsroomAddr)
+	log.Infof("Adding watchers for newsroom at address: %v", newsroomAddr.Hex())
 	return nil
 }
 
@@ -74,6 +74,6 @@ func (n *RemoveNewsroomWatchersTrigger) Run(collector *EventCollector,
 	if err != nil {
 		return fmt.Errorf("Error removing watchers: err: %v", err)
 	}
-	log.Infof("Removing watchers for newsroom at address: %v", newsroomAddr)
+	log.Infof("Removing watchers for newsroom at address: %v", newsroomAddr.Hex())
 	return nil
 }

--- a/pkg/persistence/postgrespersister.go
+++ b/pkg/persistence/postgrespersister.go
@@ -5,11 +5,13 @@ package persistence // import "github.com/joincivil/civil-events-crawler/pkg/per
 import (
 	"bytes"
 	"fmt"
-	log "github.com/golang/glog"
 	"strings"
+
+	log "github.com/golang/glog"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/jmoiron/sqlx"
+
 	// driver for postgresql
 	_ "github.com/lib/pq"
 
@@ -124,6 +126,7 @@ func (p *PostgresPersister) saveEventsToTable(events []*model.Event, tableName s
 		if err != nil {
 			return err
 		}
+		log.Infof("saveEventsToTable: saved: %v, %v", event.EventType(), event.TxHash().Hex()) // Debug, remove later
 	}
 	return nil
 }
@@ -191,6 +194,7 @@ func (p *PostgresPersister) saveEventToTable(query string, event *model.Event) e
 	if err != nil {
 		return fmt.Errorf("Error saving event to table: err %v: event: %T", err, dbEvent.LogPayload["Data"])
 	}
+	log.Infof("saveEventToTable: done") // Debug, remove later
 	return nil
 }
 


### PR DESCRIPTION
Saw an issue where after the crawler runs for a while stops saving expected events to the DB.  No errors received in the logs and needed  to be bounced to start again.  

Hypothesis:
Could either be some logic issue where those events should not be saved, some issue or timeout with connection to the DB or a `tunny` golang goroutine pool issue locking up the routines.   

Due to lack of logged errors, adding some additional INFO logging to help trace since it only happens on long running processes.

Seems to be highly related to the previous issue in which I thought it was a problem with the websockets dropping events.

[ch2717]