### PR TITLE
update pubsub so you can manually ack the message

### DIFF
--- a/pkg/utils/pubsub.go
+++ b/pkg/utils/pubsub.go
@@ -72,6 +72,7 @@ type GooglePubSub struct {
 	numRunningSubscribe    int
 }
 
+// SubscribeConfig is a config for the wrapper around a Google Pubsub Subscription
 type SubscribeConfig struct {
 	Name    string
 	AutoAck bool


### PR DESCRIPTION
adds `StartSubscribersWithConfig` method so that you can choose to manually ack messages (default= automatically ack)

adds `CreateSubscriptionWithConfig` so you can create a new subscription and specify AckDeadline and to retain acked messages. This method leaks `pubsub.SubscriptionConfig` API to the client, so if this is smelly I am happy to remove it or wrap it in our own config struct