### PR TITLE
Filter newsroom contract after new watcher is added on Application event

### DIFF
--- a/pkg/eventcollector/eventcollector.go
+++ b/pkg/eventcollector/eventcollector.go
@@ -154,6 +154,7 @@ func (c *EventCollector) handleEvent(payload interface{}) interface{} {
 	if err != nil {
 		log.Errorf("Error calling triggers: err: %v", err)
 		errors <- err
+		return nil
 	}
 
 	// We need to get past newsroom events for the newsroom contract of a newly added watcher

--- a/pkg/eventcollector/eventcollector.go
+++ b/pkg/eventcollector/eventcollector.go
@@ -156,7 +156,7 @@ func (c *EventCollector) handleEvent(payload interface{}) interface{} {
 		errors <- err
 	}
 
-	// We need to get past events for this newsroom contractls
+	// We need to get past newsroom events for the newsroom contract of a newly added watcher
 	if event.EventType() == "Application" {
 		newsroomAddr := event.EventPayload()["ListingAddress"].(common.Address)
 		// Check in persistence to see if events exist for this newsroom and update starting blocks
@@ -166,7 +166,7 @@ func (c *EventCollector) handleEvent(payload interface{}) interface{} {
 			errors <- err
 			return nil
 		}
-		log.Infof("Found %v past newsroom events at address %v", len(nwsrmEvents), newsroomAddr.Hex())
+		log.Infof("Found %v newsroom events for address %v after filtering", len(nwsrmEvents), newsroomAddr.Hex())
 		// Save events
 		err = c.eventDataPersister.SaveEvents(nwsrmEvents)
 		if err != nil {

--- a/pkg/eventcollector/eventcollector_test.go
+++ b/pkg/eventcollector/eventcollector_test.go
@@ -444,8 +444,9 @@ func TestEventCollectorCollection(t *testing.T) {
 	if len(events) == 0 {
 		t.Error("Should have seen some events in the persister")
 	}
-	if len(events) != 6 {
-		t.Errorf("Should have seen 6 events in the persister, saw %v instead", len(events))
+
+	if len(events) != 9 {
+		t.Errorf("Should have seen 9 events in the persister, saw %v instead", len(events))
 	}
 
 	err = collector.StopCollection()

--- a/pkg/retriever/retriever.go
+++ b/pkg/retriever/retriever.go
@@ -48,11 +48,14 @@ func (r *EventRetriever) Retrieve() error {
 
 // SortEventsByBlock sorts events in PastEvents by block number
 // NOTE(IS): This is not optimal, but for now checking that values exist outside of sort
-func (r *EventRetriever) SortEventsByBlock() error {
-	pastEvents := r.PastEvents
-	sort.Slice(pastEvents, func(i, j int) bool {
-		blockNumber1 := pastEvents[i].BlockNumber()
-		blockNumber2 := pastEvents[j].BlockNumber()
+// Pass in nil if you want to sort retriever.PastEvents
+func (r *EventRetriever) SortEventsByBlock(events []*model.Event) error {
+	if events == nil {
+		events = r.PastEvents
+	}
+	sort.Slice(events, func(i, j int) bool {
+		blockNumber1 := events[i].BlockNumber()
+		blockNumber2 := events[j].BlockNumber()
 		return blockNumber1 < blockNumber2
 	})
 	return nil


### PR DESCRIPTION
- Adding an extra step in `handleEvent` so that if there are newsroom events we haven't yet filtered for, we make sure to filter for them.
- Modified sorting of retrieved events so that newly added newsroom events are sorted with it as well