### PR TITLE
Reduced Websocket Ping from 30 Mins to 5 Mins

### DIFF
--- a/cmd/crawler/main.go
+++ b/cmd/crawler/main.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	websocketPingDelaySecs = 60 * 30 // 30 mins
+	websocketPingDelaySecs = 60 * 5 // 5 mins
 )
 
 func contractFilterers(config *utils.CrawlerConfig) []model.ContractFilterers {
@@ -128,11 +128,12 @@ Loop:
 	for {
 		select {
 		case <-time.After(websocketPingDelaySecs * time.Second):
-			header, err := client.HeaderByNumber(context.TODO(), nil)
+			_, err := client.HeaderByNumber(context.TODO(), nil)
+			// header, err := client.HeaderByNumber(context.TODO(), nil)
 			if err != nil {
 				log.Errorf("Ping header by number failed: err: %v", err)
 			}
-			log.Infof("Ping success: block number: %v", header.Number)
+			// log.Infof("Ping success: block number: %v", header.Number)
 
 		case <-killChan:
 			log.Infof("Closing websocket ping")


### PR DESCRIPTION
- Noticing some new connection closed errors in the logs, so this is an attempt to keep the WS connection alive by calling `HeaderByNumber` ping more often.  It hasn't happened before, but I wonder if it is bc we recently switched back to Infura.  Might have to do more digging if this doesn't improve it. 
- Commented out the ping logging since it is pinging more often and it might consume unnecessary storage.

Odd bc in the Infura docs, it says that `Idle connections that exceed beyond an hour will get disconnected. Adding 'pings' to your websocket connection will prevent the connection from going idle. Any unrecognized requests will trigger the server to close the connection with an error message.`  I wonder if pinging by calling a command is not working.  However, it might be more difficult to build a real `PING` as all the WS code is currently built in the go-ethereum lib.