### PR TITLE
CIVIL-308: Back to trigger

### DIFF
--- a/pkg/eventcollector/eventcollector.go
+++ b/pkg/eventcollector/eventcollector.go
@@ -142,7 +142,7 @@ func (c *EventCollector) handleEvent(payload interface{}) interface{} {
 		eventType, txHash.Hex(), hash) // Debug, remove later
 
 	if c.crawlerPubSub != nil {
-		err = c.crawlerPubSub.PublishTriggerMessage()
+		err = c.crawlerPubSub.PublishProcessorTriggerMessage()
 		if err != nil {
 			return fmt.Errorf("Error sending message for event %v to pubsub: %v", event.Hash(), err)
 		}
@@ -224,7 +224,7 @@ func (c *EventCollector) StartCollection() error {
 	}
 
 	if c.crawlerPubSub != nil {
-		err = c.crawlerPubSub.PublishTriggerMessage()
+		err = c.crawlerPubSub.PublishProcessorTriggerMessage()
 		if err != nil {
 			return err
 		}

--- a/pkg/eventcollector/eventcollector.go
+++ b/pkg/eventcollector/eventcollector.go
@@ -493,10 +493,12 @@ func (c *EventCollector) CheckRetrievedEventsForNewsroom(pastEvents []*model.Eve
 				log.Infof("Adding Newsroom filterer for %v", newsroomAddr.Hex())
 				newFilterer := filterer.NewNewsroomContractFilterers(newsroomAddr)
 				additionalNewsroomFilterers = append(additionalNewsroomFilterers, newFilterer)
+				existingFiltererNewsroomAddr[newsroomAddr] = true
 			}
 			if _, ok := existingWatcherNewsroomAddr[newsroomAddr]; !ok {
 				newWatcher := watcher.NewNewsroomContractWatchers(newsroomAddr)
 				watchersToAdd[newsroomAddr] = newWatcher
+				existingWatcherNewsroomAddr[newsroomAddr] = true
 			}
 		}
 		if event.EventType() == "ListingRemoved" {

--- a/pkg/eventcollector/eventcollector.go
+++ b/pkg/eventcollector/eventcollector.go
@@ -142,7 +142,7 @@ func (c *EventCollector) handleEvent(payload interface{}) interface{} {
 		eventType, txHash.Hex(), hash) // Debug, remove later
 
 	if c.crawlerPubSub != nil {
-		err = c.crawlerPubSub.PublishWatchedEventMessage(event)
+		err = c.crawlerPubSub.PublishTriggerMessage()
 		if err != nil {
 			return fmt.Errorf("Error sending message for event %v to pubsub: %v", event.Hash(), err)
 		}
@@ -178,13 +178,11 @@ func (c *EventCollector) handleEvent(payload interface{}) interface{} {
 			return fmt.Errorf("Error saving events for application %v", err)
 		}
 		log.Infof("Saved newsroom events at address %v, hsh: %v", newsroomAddr.Hex(), hash) //Debug, remove later
-		// NOTE(IS): This may not be the most efficient way to do this. Can think of a better solution later.
+
 		if c.crawlerPubSub != nil {
-			for _, event := range newsroomEvents {
-				err = c.crawlerPubSub.PublishWatchedEventMessage(event)
-				if err != nil {
-					return fmt.Errorf("Error sending message for event %v to pubsub: %v", event.Hash(), err)
-				}
+			err := c.crawlerPubSub.PublishNewsroomExceptionMessage(newsroomAddr.Hex())
+			if err != nil {
+				return fmt.Errorf("Error sending message for event %v to pubsub: %v", event.Hash(), err)
 			}
 		}
 	}
@@ -226,7 +224,7 @@ func (c *EventCollector) StartCollection() error {
 	}
 
 	if c.crawlerPubSub != nil {
-		err = c.crawlerPubSub.PublishFilteringFinishedMessage()
+		err = c.crawlerPubSub.PublishTriggerMessage()
 		if err != nil {
 			return err
 		}

--- a/pkg/model/persistinterfaces.go
+++ b/pkg/model/persistinterfaces.go
@@ -38,9 +38,10 @@ type RetrieverMetaDataPersister interface {
 // RetrieveEventsCriteria contains the retrieval criteria for a RetrieveEvents
 // query.
 type RetrieveEventsCriteria struct {
-	Hash   string `db:"hash"`
-	Offset int    `db:"offset"`
-	Count  int    `db:"count"`
+	Hash            string `db:"hash"`
+	ContractAddress string `db:"contract_address"`
+	Offset          int    `db:"offset"`
+	Count           int    `db:"count"`
 	// Reverse reverses by id in DB
 	Reverse   bool   `db:"reverse"`
 	FromTs    int64  `db:"fromts"`

--- a/pkg/model/persistinterfaces.go
+++ b/pkg/model/persistinterfaces.go
@@ -38,10 +38,11 @@ type RetrieverMetaDataPersister interface {
 // RetrieveEventsCriteria contains the retrieval criteria for a RetrieveEvents
 // query.
 type RetrieveEventsCriteria struct {
-	Hash            string `db:"hash"`
-	ContractAddress string `db:"contract_address"`
-	Offset          int    `db:"offset"`
-	Count           int    `db:"count"`
+	Hash            string   `db:"hash"`
+	ContractAddress string   `db:"contract_address"`
+	Offset          int      `db:"offset"`
+	Count           int      `db:"count"`
+	ExcludeHashes   []string `db:"exclude_hashes"`
 	// Reverse reverses by id in DB
 	Reverse   bool   `db:"reverse"`
 	FromTs    int64  `db:"fromts"`

--- a/pkg/persistence/postgres/event.go
+++ b/pkg/persistence/postgres/event.go
@@ -55,8 +55,7 @@ func CreateEventTableIndicesString(tableName string) string {
 		CREATE INDEX IF NOT EXISTS event_event_type_idx ON %s (event_type);
 		CREATE INDEX IF NOT EXISTS event_contract_address_idx ON %s (contract_address);
 		CREATE INDEX IF NOT EXISTS event_timestamp_idx ON %s (timestamp);
-		CREATE INDEX IF NOT EXISTS event_hash_idx ON %s (hash);
-	`, tableName, tableName, tableName, tableName)
+	`, tableName, tableName, tableName)
 	return queryString
 }
 

--- a/pkg/persistence/postgres/event.go
+++ b/pkg/persistence/postgres/event.go
@@ -55,7 +55,8 @@ func CreateEventTableIndicesString(tableName string) string {
 		CREATE INDEX IF NOT EXISTS event_event_type_idx ON %s (event_type);
 		CREATE INDEX IF NOT EXISTS event_contract_address_idx ON %s (contract_address);
 		CREATE INDEX IF NOT EXISTS event_timestamp_idx ON %s (timestamp);
-	`, tableName, tableName, tableName)
+		CREATE INDEX IF NOT EXISTS event_hash_idx ON %s (hash);
+	`, tableName, tableName, tableName, tableName)
 	return queryString
 }
 

--- a/pkg/persistence/postgrespersister.go
+++ b/pkg/persistence/postgrespersister.go
@@ -189,6 +189,11 @@ func (p *PostgresPersister) retrieveEventsQuery(tableName string, criteria *mode
 			p.addWhereAnd(queryBuf)
 			queryBuf.WriteString(" contract_address = :contract_address") // nolint: gosec
 		}
+		if len(criteria.ExcludeHashes) > 0 {
+			p.addWhereAnd(queryBuf)
+			notInQuery := fmt.Sprintf(" hash NOT IN ('%v')", strings.Join(criteria.ExcludeHashes, "','"))
+			queryBuf.WriteString(notInQuery) // nolint: gosec
+		}
 		if criteria.Reverse {
 			queryBuf.WriteString(" ORDER BY id DESC") // nolint: gosec
 		} else {

--- a/pkg/persistence/postgrespersister.go
+++ b/pkg/persistence/postgrespersister.go
@@ -185,6 +185,10 @@ func (p *PostgresPersister) retrieveEventsQuery(tableName string, criteria *mode
 			p.addWhereAnd(queryBuf)
 			queryBuf.WriteString(" event_type = :eventtype") // nolint: gosec
 		}
+		if criteria.ContractAddress != "" {
+			p.addWhereAnd(queryBuf)
+			queryBuf.WriteString(" contract_address = :contract_address") // nolint: gosec
+		}
 		if criteria.Reverse {
 			queryBuf.WriteString(" ORDER BY id DESC") // nolint: gosec
 		} else {

--- a/pkg/persistence/postgrespersister.go
+++ b/pkg/persistence/postgrespersister.go
@@ -1,6 +1,5 @@
 // Package persistence contains components to interact with the DB
 package persistence // import "github.com/joincivil/civil-events-crawler/pkg/persistence"
-// NOTE(IS): Only tested with event wrappers around contracts implemented: civiltcr and newsroom
 
 import (
 	"bytes"
@@ -58,7 +57,7 @@ func (p *PostgresPersister) SaveEvents(events []*model.Event) error {
 	return p.saveEventsToTable(events, eventTableName)
 }
 
-// RetrieveEvents retrieves the Events given an offset, count, and asc/dec bool
+// RetrieveEvents retrieves the Events given an offset, count, and asc/dec bool. Ordered by db id.
 func (p *PostgresPersister) RetrieveEvents(criteria *model.RetrieveEventsCriteria) ([]*model.Event, error) {
 	return p.retrieveEventsFromTable(eventTableName, criteria)
 }
@@ -167,37 +166,41 @@ func (p *PostgresPersister) retrieveEventsFromTable(tableName string, criteria *
 
 func (p *PostgresPersister) retrieveEventsQuery(tableName string, criteria *model.RetrieveEventsCriteria) string {
 	queryBuf := bytes.NewBufferString("SELECT ")
-	fields, _ := cpostgres.StructFieldsForQuery(postgres.Event{}, false, "")
+	fields, _ := cpostgres.StructFieldsForQuery(postgres.Event{}, false, "e")
 	queryBuf.WriteString(fields)    // nolint: gosec
 	queryBuf.WriteString(" FROM ")  // nolint: gosec
 	queryBuf.WriteString(tableName) // nolint: gosec
+	queryBuf.WriteString(" AS e ")  // nolint: gosec
 	if criteria.Hash != "" {
 		// If querying by hash, we don't need any other criteria
-		queryBuf.WriteString(" WHERE hash = :hash") // nolint: gosec
+		queryBuf.WriteString(" WHERE e.hash = :hash") // nolint: gosec
 	} else {
 		if criteria.FromTs > 0 {
-			queryBuf.WriteString(" WHERE timestamp >= :fromts") // nolint: gosec
+			queryBuf.WriteString(" WHERE e.timestamp >= :fromts") // nolint: gosec
 		} else if criteria.BeforeTs > 0 {
 			p.addWhereAnd(queryBuf)
-			queryBuf.WriteString(" timestamp < :beforets") // nolint: gosec
+			queryBuf.WriteString(" e.timestamp < :beforets") // nolint: gosec
 		}
 		if criteria.EventType != "" {
 			p.addWhereAnd(queryBuf)
-			queryBuf.WriteString(" event_type = :eventtype") // nolint: gosec
+			queryBuf.WriteString(" e.event_type = :eventtype") // nolint: gosec
 		}
 		if criteria.ContractAddress != "" {
 			p.addWhereAnd(queryBuf)
-			queryBuf.WriteString(" contract_address = :contract_address") // nolint: gosec
+			queryBuf.WriteString(" e.contract_address = :contract_address") // nolint: gosec
 		}
+		//TODO(IS): the following query DOES NOT WORK
 		if len(criteria.ExcludeHashes) > 0 {
+			sFields, _ := cpostgres.StructFieldsForQuery(postgres.Event{}, false, "")
 			p.addWhereAnd(queryBuf)
-			notInQuery := fmt.Sprintf(" hash NOT IN ('%v')", strings.Join(criteria.ExcludeHashes, "','"))
+			notInQuery := fmt.Sprintf(" NOT EXISTS (SELECT %v FROM %v WHERE e.hash IN ('%v'))", sFields,
+				tableName, strings.Join(criteria.ExcludeHashes, "','"))
 			queryBuf.WriteString(notInQuery) // nolint: gosec
 		}
 		if criteria.Reverse {
-			queryBuf.WriteString(" ORDER BY id DESC") // nolint: gosec
+			queryBuf.WriteString(" ORDER BY e.id DESC") // nolint: gosec
 		} else {
-			queryBuf.WriteString(" ORDER BY id") // nolint: gosec
+			queryBuf.WriteString(" ORDER BY e.id") // nolint: gosec
 		}
 		if criteria.Offset > 0 {
 			queryBuf.WriteString(" OFFSET :offset") // nolint: gosec

--- a/pkg/persistence/postgrespersister.go
+++ b/pkg/persistence/postgrespersister.go
@@ -176,7 +176,7 @@ func (p *PostgresPersister) retrieveEventsQuery(tableName string, criteria *mode
 		queryBuf.WriteString(" WHERE hash = :hash") // nolint: gosec
 	} else {
 		if criteria.FromTs > 0 {
-			queryBuf.WriteString(" WHERE timestamp > :fromts") // nolint: gosec
+			queryBuf.WriteString(" WHERE timestamp >= :fromts") // nolint: gosec
 		} else if criteria.BeforeTs > 0 {
 			p.addWhereAnd(queryBuf)
 			queryBuf.WriteString(" timestamp < :beforets") // nolint: gosec

--- a/pkg/persistence/postgrespersister.go
+++ b/pkg/persistence/postgrespersister.go
@@ -135,9 +135,9 @@ func (p *PostgresPersister) saveEventsToTable(events []*model.Event, tableName s
 	for _, event := range events {
 		err := p.saveEventToTable(queryString, event)
 		if err != nil {
-			return err
+			return fmt.Errorf("Error saving %v to db, err: %v", event.Hash(), err)
 		}
-		log.Infof("saveEventsToTable: saved: %v, %v", event.EventType(), event.TxHash().Hex()) // Debug, remove later
+		log.Infof("saveEventsToTable: saved: %v, %v", event.EventType(), event.Hash()) // Debug, remove later
 	}
 	return nil
 }

--- a/pkg/persistence/postgrespersister_test.go
+++ b/pkg/persistence/postgrespersister_test.go
@@ -1045,3 +1045,58 @@ func TestRetrieveEvents(t *testing.T) {
 		t.Errorf("Should have only seen 1 event but saw %v", len(events))
 	}
 }
+
+func TestRetrieveEventsExcludingHash(t *testing.T) {
+	civilEventsFromContract, err := setupEvents(true)
+	if err != nil {
+		t.Errorf("Couldn't setup event %v", err)
+	}
+	timeToHash := make(map[int64][]string)
+
+	for _, event := range civilEventsFromContract {
+		ts := event.Timestamp()
+		timeToHash[ts] = append(timeToHash[ts], event.Hash())
+	}
+
+	persister, err := setupTestTable()
+	if err != nil {
+		t.Error(err)
+	}
+	defer deleteTestTableForTesting(t, persister)
+
+	err = persister.saveEventsToTable(civilEventsFromContract, eventTestTableName)
+	if err != nil {
+		t.Errorf("Should not have seen error when saving events to table: %v", err)
+	}
+
+	// Choose random time for lastTs
+	lastTs := civilEventsFromContract[0].Timestamp()
+	// Take 1 hash to exclude
+	excluding := timeToHash[lastTs][:1]
+	events, err := persister.retrieveEventsFromTable(eventTestTableName, &model.RetrieveEventsCriteria{
+		FromTs:        lastTs,
+		ExcludeHashes: excluding,
+	})
+	if err != nil {
+		t.Errorf("Should not have received error when retrieving events: err: %v", err)
+	}
+	numExpectedEvents := len(civilEventsFromContract) - len(excluding)
+	if len(events) != numExpectedEvents {
+		t.Errorf("Was expecting to get %v events but got %v instead", numExpectedEvents, len(events))
+	}
+
+	// Take 3 hashes to exclude
+	excluding = timeToHash[lastTs][:3]
+	events, err = persister.retrieveEventsFromTable(eventTestTableName, &model.RetrieveEventsCriteria{
+		FromTs:        lastTs,
+		ExcludeHashes: excluding,
+	})
+	if err != nil {
+		t.Errorf("Should not have received error when retrieving events: err: %v", err)
+	}
+	numExpectedEvents = len(civilEventsFromContract) - len(excluding)
+	if len(events) != numExpectedEvents {
+		t.Errorf("Was expecting to get %v events but got %v instead", numExpectedEvents, len(events))
+	}
+
+}

--- a/pkg/persistence/postgrespersister_test.go
+++ b/pkg/persistence/postgrespersister_test.go
@@ -1011,10 +1011,10 @@ func TestRetrieveEvents(t *testing.T) {
 	if err != nil {
 		t.Errorf("Should not have received error when retrieving events: err: %v", err)
 	}
-	if len(events) != 3 {
+	if len(events) != 4 {
 		t.Errorf("Should have seen 3 events: %v", len(events))
 	}
-	if events[0].EventType() != "Challenge" {
+	if events[0].EventType() != "ApplicationWhitelisted" {
 		t.Errorf("Should have seen the type challenge")
 	}
 

--- a/pkg/pubsub/pubsub.go
+++ b/pkg/pubsub/pubsub.go
@@ -51,8 +51,8 @@ func (c *CrawlerPubSub) BuildMessage(newsroomException bool,
 	return &cpubsub.GooglePubSubMsg{Topic: c.Topic, Payload: string(msgBytes)}, nil
 }
 
-// PublishTriggerMessage publishes an empty message to process events
-func (c *CrawlerPubSub) PublishTriggerMessage() error {
+// PublishProcessorTriggerMessage publishes an empty message to process events
+func (c *CrawlerPubSub) PublishProcessorTriggerMessage() error {
 	msg, err := c.BuildMessage(false, "")
 	if err != nil {
 		return err

--- a/pkg/pubsub/pubsub.go
+++ b/pkg/pubsub/pubsub.go
@@ -51,7 +51,7 @@ func (c *CrawlerPubSub) BuildMessage(newsroomException bool,
 	return &cpubsub.GooglePubSubMsg{Topic: c.Topic, Payload: string(msgBytes)}, nil
 }
 
-// PublishTriggerMessage publishes a message to send a message
+// PublishTriggerMessage publishes an empty message to process events
 func (c *CrawlerPubSub) PublishTriggerMessage() error {
 	msg, err := c.BuildMessage(false, "")
 	if err != nil {

--- a/pkg/pubsub/pubsub.go
+++ b/pkg/pubsub/pubsub.go
@@ -2,7 +2,6 @@ package pubsub
 
 import (
 	"encoding/json"
-	"github.com/joincivil/civil-events-crawler/pkg/model"
 	cpubsub "github.com/joincivil/go-common/pkg/pubsub"
 )
 
@@ -23,8 +22,8 @@ func NewCrawlerPubSub(projectID string, topic string) (*CrawlerPubSub, error) {
 
 // CrawlerPubSubMessage is the message sent from the crawler
 type CrawlerPubSubMessage struct {
-	Timestamp int64  `json:"timestamp"`
-	Hash      string `json:"hash"`
+	NewsroomException bool   `json:"newsroomException"`
+	ContractAddress   string `json:"contractAddress"`
 }
 
 // StartPublishers starts the publishers
@@ -38,10 +37,11 @@ func (c *CrawlerPubSub) StopPublishers() error {
 }
 
 // BuildMessage builds a message for the publisher
-func (c *CrawlerPubSub) BuildMessage(timestamp int64, hash string) (*cpubsub.GooglePubSubMsg, error) {
+func (c *CrawlerPubSub) BuildMessage(newsroomException bool,
+	contractAddress string) (*cpubsub.GooglePubSubMsg, error) {
 	msg := CrawlerPubSubMessage{
-		Timestamp: timestamp,
-		Hash:      hash,
+		NewsroomException: newsroomException,
+		ContractAddress:   contractAddress,
 	}
 	msgBytes, err := json.Marshal(msg)
 	if err != nil {
@@ -51,24 +51,18 @@ func (c *CrawlerPubSub) BuildMessage(timestamp int64, hash string) (*cpubsub.Goo
 	return &cpubsub.GooglePubSubMsg{Topic: c.Topic, Payload: string(msgBytes)}, nil
 }
 
-//BuildFilteringFinishedMessage is the message sent when filtering is done. It has no timestamp or hash
-// because there are a bunch of events associated with this.
-func (c *CrawlerPubSub) BuildFilteringFinishedMessage() (*cpubsub.GooglePubSubMsg, error) {
-	return c.BuildMessage(0, "")
-}
-
-// PublishFilteringFinishedMessage sends a message to pubsub that filtering has finished
-func (c *CrawlerPubSub) PublishFilteringFinishedMessage() error {
-	msg, err := c.BuildFilteringFinishedMessage()
+// PublishTriggerMessage publishes a message to send a message
+func (c *CrawlerPubSub) PublishTriggerMessage() error {
+	msg, err := c.BuildMessage(false, "")
 	if err != nil {
 		return err
 	}
 	return c.GooglePubsub.Publish(msg)
 }
 
-// PublishWatchedEventMessage sends a message that an event has been watched for
-func (c *CrawlerPubSub) PublishWatchedEventMessage(event *model.Event) error {
-	msg, err := c.BuildMessage(event.Timestamp(), event.Hash())
+// PublishNewsroomExceptionMessage sends a message to pubsub to get all past events for a newsroom
+func (c *CrawlerPubSub) PublishNewsroomExceptionMessage(contractAddress string) error {
+	msg, err := c.BuildMessage(true, contractAddress)
 	if err != nil {
 		return err
 	}

--- a/pkg/pubsub/pubsub_test.go
+++ b/pkg/pubsub/pubsub_test.go
@@ -75,11 +75,11 @@ func returnTestEvent(t *testing.T) *model.Event {
 func TestBuildMessage(t *testing.T) {
 	cps := setupCrawlerPubSub(t)
 	event := returnTestEvent(t)
-	message, err := cps.BuildMessage(0, event.Hash())
+	message, err := cps.BuildMessage(true, event.ContractAddress().Hex())
 	if err != nil {
 		t.Errorf("Error building message for pubsub %v", err)
 	}
-	if message.Payload != fmt.Sprintf("{\"timestamp\":0,\"hash\":\"%s\"}", event.Hash()) {
+	if message.Payload != fmt.Sprintf("{\"newsroomException\":true,\"contractAddress\":\"%s\"}", event.ContractAddress().Hex()) {
 		t.Errorf("Message payload contents are wrong %v", message.Payload)
 	}
 	if message.Topic != "testTopic" {
@@ -146,8 +146,8 @@ func TestPublishMessages(t *testing.T) {
 
 	go func() {
 		time.Sleep(10)
-		cps.PublishFilteringFinishedMessage()
-		cps.PublishWatchedEventMessage(event)
+		cps.PublishTriggerMessage()
+		cps.PublishNewsroomExceptionMessage(event.ContractAddress().Hex())
 
 	}()
 

--- a/pkg/pubsub/pubsub_test.go
+++ b/pkg/pubsub/pubsub_test.go
@@ -146,7 +146,7 @@ func TestPublishMessages(t *testing.T) {
 
 	go func() {
 		time.Sleep(10)
-		cps.PublishTriggerMessage()
+		cps.PublishProcessorTriggerMessage()
 		cps.PublishNewsroomExceptionMessage(event.ContractAddress().Hex())
 
 	}()


### PR DESCRIPTION
Changes in `RetrieveEventsCriteria`:
- FromTs is inclusive
- To avoid getting duplicate events in processor, added additional criteria to specify hashes of events you don't want to include in results.
- Added hash as an event table index. Will have to update DB manually.

Changes in `pubsub.go`
- Now there are 2 new functions publishing of messages as we talked about IRL: `PublishTriggerMessage` and `PublishNewsroomExceptionMessage`. 