### PR TITLE
Separate HTTP and Websocket Ethclients; Bug Fix for Additional Newsroom Starting Blocks

### DIFF
--- a/cmd/crawler/main.go
+++ b/cmd/crawler/main.go
@@ -158,7 +158,7 @@ func isWebsocketURL(rawurl string) bool {
 	return false
 }
 
-func setupHttpEthClient(config *utils.CrawlerConfig) (*ethclient.Client, error) {
+func setupHTTPEthClient(config *utils.CrawlerConfig) (*ethclient.Client, error) {
 	if isWebsocketURL(config.EthAPIURL) {
 		return nil, nil
 	}
@@ -200,7 +200,7 @@ func enableGoEtherumLogging() {
 func startUp(config *utils.CrawlerConfig) error {
 	killChan := make(chan bool)
 
-	httpClient, err := setupHttpEthClient(config)
+	httpClient, err := setupHTTPEthClient(config)
 	if err != nil {
 		return err
 	}

--- a/pkg/eventcollector/eventcollector.go
+++ b/pkg/eventcollector/eventcollector.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"reflect"
 	"runtime"
 	"sync"
 
@@ -35,7 +36,8 @@ const (
 type Config struct {
 	Chain              ethereum.ChainReader
 	RetryChain         eth.RetryChainReader
-	Client             bind.ContractBackend
+	HTTPClient         bind.ContractBackend
+	WsClient           bind.ContractBackend
 	Filterers          []model.ContractFilterers
 	Watchers           []model.ContractWatchers
 	RetrieverPersister model.RetrieverMetaDataPersister
@@ -43,7 +45,6 @@ type Config struct {
 	EventDataPersister model.EventDataPersister
 	Triggers           []Trigger
 	StartBlock         uint64
-	DisableListener    bool
 	CrawlerPubSub      *pubsub.CrawlerPubSub
 }
 
@@ -52,7 +53,8 @@ func NewEventCollector(config *Config) *EventCollector {
 	eventcollector := &EventCollector{
 		chain:              config.Chain,
 		retryChain:         eth.RetryChainReader{ChainReader: config.Chain},
-		client:             config.Client,
+		httpClient:         config.HTTPClient,
+		wsClient:           config.WsClient,
 		filterers:          config.Filterers,
 		watchers:           config.Watchers,
 		retrieverPersister: config.RetrieverPersister,
@@ -62,7 +64,6 @@ func NewEventCollector(config *Config) *EventCollector {
 		startBlock:         config.StartBlock,
 		startChan:          make(chan bool),
 		quitChan:           make(chan bool),
-		disableListener:    config.DisableListener,
 		crawlerPubSub:      config.CrawlerPubSub,
 	}
 	return eventcollector
@@ -74,7 +75,9 @@ type EventCollector struct {
 
 	retryChain eth.RetryChainReader
 
-	client bind.ContractBackend
+	httpClient bind.ContractBackend
+
+	wsClient bind.ContractBackend
 
 	triggers []Trigger
 
@@ -105,8 +108,6 @@ type EventCollector struct {
 	mutex sync.Mutex
 
 	headerCache *eth.BlockHeaderCache
-
-	disableListener bool
 
 	crawlerPubSub *pubsub.CrawlerPubSub
 }
@@ -195,7 +196,7 @@ func (c *EventCollector) handleEvent(payload interface{}) interface{} {
 func (c *EventCollector) FilterAddedNewsroomContract(newsroomAddr common.Address) ([]*model.Event, error) {
 	nwsrmFilterer := filterer.NewNewsroomContractFilterers(newsroomAddr)
 	c.updateFiltererStartingBlock(nwsrmFilterer)
-	retrieve := retriever.NewEventRetriever(c.client, []model.ContractFilterers{nwsrmFilterer})
+	retrieve := retriever.NewEventRetriever(c.httpClient, []model.ContractFilterers{nwsrmFilterer})
 	err := retrieve.Retrieve()
 	if err != nil {
 		return nil, err
@@ -217,7 +218,9 @@ func (c *EventCollector) StartCollection() error {
 		return err
 	}
 
-	if c.disableListener {
+	// nil gotcha appears
+	// https://divan.github.io/posts/avoid_gotchas/#interfaces
+	if c.wsClient == nil || reflect.ValueOf(c.wsClient).IsNil() {
 		log.Infof("Listener is disabled, not starting")
 		c.sendStartSignal()
 		return nil
@@ -285,7 +288,7 @@ func (c *EventCollector) startListener() error {
 	defer c.mutex.Unlock()
 	c.mutex.Lock()
 
-	c.listen = listener.NewEventListener(c.client, c.watchers)
+	c.listen = listener.NewEventListener(c.wsClient, c.watchers)
 	if c.listen == nil {
 		return errors.New("Listener should not be nil")
 	}
@@ -469,7 +472,7 @@ func (c *EventCollector) updateEventTimeFromBlockHeader(event *model.Event) erro
 
 func (c *EventCollector) retrieveEvents(filterers []model.ContractFilterers) error {
 	c.updateRetrieverStartingBlocks()
-	c.retrieve = retriever.NewEventRetriever(c.client, filterers)
+	c.retrieve = retriever.NewEventRetriever(c.httpClient, filterers)
 	return c.retrieve.Retrieve()
 }
 

--- a/pkg/eventcollector/eventcollector.go
+++ b/pkg/eventcollector/eventcollector.go
@@ -402,8 +402,8 @@ func (c *EventCollector) sendStartSignal() {
 }
 
 // UpdateStartingBlocks updates starting blocks for retriever based on persistence
-func (c *EventCollector) updateRetrieverStartingBlocks() {
-	for _, filter := range c.filterers {
+func (c *EventCollector) updateRetrieverStartingBlocks(filterers []model.ContractFilterers) {
+	for _, filter := range filterers {
 		c.updateFiltererStartingBlock(filter)
 	}
 }
@@ -471,7 +471,7 @@ func (c *EventCollector) updateEventTimeFromBlockHeader(event *model.Event) erro
 }
 
 func (c *EventCollector) retrieveEvents(filterers []model.ContractFilterers) error {
-	c.updateRetrieverStartingBlocks()
+	c.updateRetrieverStartingBlocks(filterers)
 	c.retrieve = retriever.NewEventRetriever(c.httpClient, filterers)
 	return c.retrieve.Retrieve()
 }

--- a/pkg/eventcollector/eventcollector_test.go
+++ b/pkg/eventcollector/eventcollector_test.go
@@ -183,7 +183,8 @@ func setupTestCollector(contracts *cutils.AllTestContracts) *eventcollector.Even
 	collector := eventcollector.NewEventCollector(
 		&eventcollector.Config{
 			Chain:              &testChainReader{},
-			Client:             contracts.Client,
+			HTTPClient:         contracts.Client,
+			WsClient:           contracts.Client,
 			Filterers:          filterers,
 			Watchers:           watchers,
 			RetrieverPersister: persister,
@@ -214,7 +215,8 @@ func setupTestCollectorTestPersister(contracts *cutils.AllTestContracts) (*event
 	collector := eventcollector.NewEventCollector(
 		&eventcollector.Config{
 			Chain:              &testChainReader{},
-			Client:             contracts.Client,
+			HTTPClient:         contracts.Client,
+			WsClient:           contracts.Client,
 			Filterers:          filterers,
 			Watchers:           watchers,
 			RetrieverPersister: persister,
@@ -246,7 +248,8 @@ func setupTestCollectorTestPersisterBadSaveEvents(contracts *cutils.AllTestContr
 	collector := eventcollector.NewEventCollector(
 		&eventcollector.Config{
 			Chain:              &testChainReader{},
-			Client:             contracts.Client,
+			HTTPClient:         contracts.Client,
+			WsClient:           contracts.Client,
 			Filterers:          filterers,
 			Watchers:           watchers,
 			RetrieverPersister: goodPersister,
@@ -278,7 +281,8 @@ func setupTestCollectorTestPersisterBadUpdateBlockData(contracts *cutils.AllTest
 	collector := eventcollector.NewEventCollector(
 		&eventcollector.Config{
 			Chain:              &testChainReader{},
-			Client:             contracts.Client,
+			HTTPClient:         contracts.Client,
+			WsClient:           contracts.Client,
 			Filterers:          filterers,
 			Watchers:           watchers,
 			RetrieverPersister: badPersister,
@@ -308,7 +312,8 @@ func setupTestCollectorBadWatcher(contracts *cutils.AllTestContracts) *eventcoll
 	collector := eventcollector.NewEventCollector(
 		&eventcollector.Config{
 			Chain:              &testChainReader{},
-			Client:             contracts.Client,
+			HTTPClient:         contracts.Client,
+			WsClient:           contracts.Client,
 			Filterers:          filterers,
 			Watchers:           watchers,
 			RetrieverPersister: persister,

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -27,7 +27,8 @@ const (
 // CrawlerConfig is the master config for the crawler derived from environment
 // variables.
 type CrawlerConfig struct {
-	EthAPIURL     string `envconfig:"eth_api_url" required:"true" desc:"Ethereum API address"`
+	EthAPIURL     string `envconfig:"eth_api_url" required:"true" desc:"Ethereum HTTP API address"`
+	EthWsAPIURL   string `envconfig:"eth_ws_api_url" desc:"Ethereum Websocket API address (optional, disables watchers if empty)"`
 	EthStartBlock uint64 `envconfig:"eth_start_block" desc:"Sets the start Eth block (default 0)" default:"0"`
 
 	// CivilListingsGraphqlURL enables call to retrieve newsroom listings from Civil.


### PR DESCRIPTION
I noticed that the HTTP interface appears to be much more efficient, stable and faster that the websocket interface for making general queries on contracts and the chain. The websocket interface tends to fail on calls on multiple `eth_getLogs` with lots of blocks.

To take advantage of this, the crawler can now be configured with two different eth client URLs (`CRAWL_ETH_API_URL`, `CRAWL_ETH_WS_API_URL`), one for HTTP and one for websockets.  Starts up respective clients, the websocket client is used exclusively for the listener/watchers. The HTTP client is used for everything else including filterers and calls for chain data.

**Also**, fixes a bug with starting blocks always being set to zero for additional newsroom filterers.  Improves performance and stability on startup when retrieving this data.