### PR TITLE
Ensure Run of Test/Lint Before Deployment on Master/Prod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,6 +173,8 @@ workflows:
           context: gcp-common
           requires:
             - build
+            - test
+            - lint
           filters:
             branches:
               only:


### PR DESCRIPTION
Noticed that the `setup-gcp` step occurs at the same time as `lint` and `test`.  Should should only occur after `lint` and `test` are successful.