### PR TITLE
Fix for Persistence Error Fail to Save Events

### DIFF
--- a/cmd/crawler/main.go
+++ b/cmd/crawler/main.go
@@ -113,7 +113,7 @@ func postgresPersister(config *utils.CrawlerConfig) *persistence.PostgresPersist
 	// Populate persistence with latest block data from events table
 	err = persister.PopulateBlockDataFromDB("event")
 	if err != nil {
-		log.Errorf("Error populating persistence from Postgresql, stopping...; err: %v", err)
+		log.Errorf("Error populating event last occurrence block data: err: %v", err)
 	}
 	return persister
 }


### PR DESCRIPTION
When an event fails to save, we end up skipping the events that come after that failed event.  This may occur if we see the same event, the method return an error and there are a bunch of events still in the queue to be saved. This attempts to save all the events and returns the last seen error if applicable.  

Attempts to do the same with populating block data and retrieving events.