### PR TITLE
CIVIL-630 - Adds Watchers for Applied and Challenged Newsroom on Startup

### DIFF
--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -18,7 +18,8 @@ import (
 )
 
 const (
-	envVarPrefix = "crawl"
+	envVarPrefix       = "crawl"
+	listingsPerRequest = 50
 )
 
 // NOTE(PN): After envconfig populates CrawlerConfig with the environment vars,
@@ -59,6 +60,39 @@ type CrawlerConfig struct {
 	SentryEnv string `split_words:"true" desc:"Sets the Sentry environment"`
 }
 
+// Edge represents an edge field in the query
+type Edge struct {
+	Node struct {
+		Name            graphql.String
+		ContractAddress graphql.String
+		Whitelisted     graphql.Boolean
+		ApprovalDate    graphql.Int
+		LastGovState    graphql.String
+	}
+}
+
+// PageInfo represents a pageinfo field in the query
+type PageInfo struct {
+	EndCursor   graphql.String
+	HasNextPage graphql.Boolean
+}
+
+// NOTE(PN): These are two separate queries because whitelistedOnly will always return
+// the value of true or false for this flag and can't be mixed with other params right now
+type whitelistedListingQuery struct {
+	TcrListings struct {
+		Edges    []Edge
+		PageInfo PageInfo
+	} `graphql:"tcrListings(first: $first, after: $after, whitelistedOnly: true)"`
+}
+
+type currentAppActiveChallengeListingQuery struct {
+	TcrListings struct {
+		Edges    []Edge
+		PageInfo PageInfo
+	} `graphql:"tcrListings(first: $first, after: $after, activeChallenge: true, currentApplication: true)"`
+}
+
 // FetchListingAddresses retrieves the list of Civil newsroom listings if given
 // the endpoint URL
 func (c *CrawlerConfig) FetchListingAddresses() error {
@@ -66,35 +100,85 @@ func (c *CrawlerConfig) FetchListingAddresses() error {
 		return nil
 	}
 
-	var listingQuery struct {
-		Listings []struct {
-			Name            graphql.String
-			ContractAddress graphql.String
-		} `graphql:"listings(whitelistedOnly: true)"`
-	}
+	first := listingsPerRequest
+	after := graphql.String("")
 
-	client := graphql.NewClient(c.CivilListingsGraphqlURL, nil)
-	err := client.Query(context.Background(), &listingQuery, nil)
-	if err != nil {
-		return err
-	}
-
-	newsroomContractName := "newsroom"
 	var addressStrings []string
 	var addressObjs []common.Address
 
+	newsroomContractName := "newsroom"
 	if c.ContractAddresses[newsroomContractName] != "" {
 		addressStrings = strings.Split(c.ContractAddresses[newsroomContractName], "|")
 	}
 
-	for _, listing := range listingQuery.Listings {
-		log.Infof("adding newsroom contract: %v, %v", listing.Name, string(listing.ContractAddress))
-		addressStrings = append(addressStrings, string(listing.ContractAddress))
-		addressObjs = append(addressObjs, common.HexToAddress(string(listing.ContractAddress)))
+	client := graphql.NewClient(c.CivilListingsGraphqlURL, nil)
+
+	// Fetch all the current applications and actively challenged
+LoopA:
+	for {
+		vars := map[string]interface{}{
+			"first": graphql.Int(first),
+			"after": after,
+		}
+
+		q := currentAppActiveChallengeListingQuery{}
+		err := client.Query(context.Background(), &q, vars)
+		if err != nil {
+			return err
+		}
+		// Look at all the result edges and capture name/addresses
+		edges := q.TcrListings.Edges
+		for _, edge := range edges {
+			listing := edge.Node
+			log.Infof("adding newsroom contract: %v, %v", listing.Name, string(listing.ContractAddress))
+			addressStrings = append(addressStrings, string(listing.ContractAddress))
+			addressObjs = append(addressObjs, common.HexToAddress(string(listing.ContractAddress)))
+		}
+
+		// Figure out next page cursor
+		if !q.TcrListings.PageInfo.HasNextPage {
+			break LoopA
+		}
+		after = q.TcrListings.PageInfo.EndCursor
 	}
 
-	c.ContractAddresses["newsroom"] = strings.Join(addressStrings, "|")
-	c.ContractAddressObjs["newsroom"] = append(c.ContractAddressObjs["newsroom"], addressObjs...)
+	// Reset after value
+	after = graphql.String("")
+
+	// Fetch all the whitelisted
+LoopB:
+	for {
+		vars := map[string]interface{}{
+			"first": graphql.Int(first),
+			"after": after,
+		}
+
+		q := whitelistedListingQuery{}
+		err := client.Query(context.Background(), &q, vars)
+		if err != nil {
+			return err
+		}
+		// Look at all the result edges and capture name/addresses
+		edges := q.TcrListings.Edges
+		for _, edge := range edges {
+			listing := edge.Node
+			log.Infof("adding newsroom contract: %v, %v", listing.Name, string(listing.ContractAddress))
+			addressStrings = append(addressStrings, string(listing.ContractAddress))
+			addressObjs = append(addressObjs, common.HexToAddress(string(listing.ContractAddress)))
+		}
+
+		// Figure out next page cursor
+		if !q.TcrListings.PageInfo.HasNextPage {
+			break LoopB
+		}
+		after = q.TcrListings.PageInfo.EndCursor
+	}
+
+	c.ContractAddresses[newsroomContractName] = strings.Join(addressStrings, "|")
+	c.ContractAddressObjs[newsroomContractName] = append(
+		c.ContractAddressObjs[newsroomContractName], addressObjs...)
+
+	log.Infof("addresses len = %v", len(addressStrings))
 	return nil
 }
 

--- a/pkg/utils/config_test.go
+++ b/pkg/utils/config_test.go
@@ -193,36 +193,56 @@ func testGraphqlResponse(w http.ResponseWriter, r *http.Request) {
 	message := `
 	{
 		"data": {
-			"listings": [
-				{
-					"name": "The Intercept",
-					"contractAddress": "0xADbB46098E06dBE18aFF2416920FF03EA6814e7b"
-				},
-				{
-					"name": "Spectrum News - NY1",
-					"contractAddress": "0x5572DBfa985b1127219ff38f4A10AdB10311725b"
-				},
-				{
-					"name": "New York Times",
-					"contractAddress": "0xF71B43B1d4a0462fA9a37F7A3E5f947804A73bfA"
-				},
-				{
-					"name": "The Drudge Report",
-					"contractAddress": "0x76a1f346aAA3a1Dc27A5b967b76B096b787055D9"
-				},
-				{
-					"name": "WWMT",
-					"contractAddress": "0xA3a7056f4727d9E8094957D937b993adB35f21fF"
-				},
-				{
-					"name": "Project Veritas",
-					"contractAddress": "0xc2A0456154456f0d4e73F6f5acbCd08Ea6A6B2E8"
-				},
-				{
-					"name": "The Los Angeles Times",
-					"contractAddress": "0xcFfd0E01AD3712B776740aa9766034850dbA2725"
+			"tcrListings": {
+				"edges": [
+					{
+						"node": {
+							"name": "The Intercept",
+							"contractAddress": "0xADbB46098E06dBE18aFF2416920FF03EA6814e7b"
+						}
+					},
+					{
+						"node": {
+							"name": "Spectrum News - NY1",
+							"contractAddress": "0x5572DBfa985b1127219ff38f4A10AdB10311725b"
+						}
+					},
+					{
+						"node": {
+							"name": "New York Times",
+							"contractAddress": "0xF71B43B1d4a0462fA9a37F7A3E5f947804A73bfA"
+						}
+					},
+					{
+						"node": {
+							"name": "The Drudge Report",
+							"contractAddress": "0x76a1f346aAA3a1Dc27A5b967b76B096b787055D9"
+						}
+					},
+					{
+						"node": {
+							"name": "WWMT",
+							"contractAddress": "0xA3a7056f4727d9E8094957D937b993adB35f21fF"
+						}
+					},
+					{
+						"node": {
+							"name": "Project Veritas",
+							"contractAddress": "0xc2A0456154456f0d4e73F6f5acbCd08Ea6A6B2E8"
+						}
+					},
+					{
+						"node": {
+							"name": "The Los Angeles Times",
+							"contractAddress": "0xcFfd0E01AD3712B776740aa9766034850dbA2725"
+						}
+					}
+				],
+				"pageInfo": {
+					"endCursor": "b2Zmc2V0fHx8MzY=",
+					"hasNextPage": false
 				}
-			]
+			}
 		}
 	}`
 	w.Write([]byte(message))
@@ -282,7 +302,8 @@ func TestFetchListingAddresses(t *testing.T) {
 		t.Errorf("Should have fetched listing addresses: len: %v, err: %v",
 			len(config.ContractAddresses["newsroom"]), err)
 	}
-	if len(config.ContractAddressObjs["newsroom"]) != 8 {
+	// 1 newsroom from config, 14 from graphql
+	if len(config.ContractAddressObjs["newsroom"]) != 15 {
 		t.Errorf("Should have fetched listing 8 address objs: len: %v, err: %v",
 			len(config.ContractAddressObjs["newsroom"]), err)
 	}


### PR DESCRIPTION
Upon startup, calls Graphql for both whitelisted, active challenges and current applications newsrooms and starts up the watchers for them.  Previously only started up whitelisted newsrooms and potentially experiencing an issue where we weren't capturing newsroom events between when the newsroom applied and when it was whitelisted if the server had restarted after application dynamically started up a watcher.