### PR TITLE
Use the Block Number and Index for Event Sorting

### DIFF
--- a/pkg/persistence/postgrespersister.go
+++ b/pkg/persistence/postgrespersister.go
@@ -399,11 +399,17 @@ func (p *PostgresPersister) retrieveEventsQuery(tableName string, criteria *mode
 				tableName, strings.Join(criteria.ExcludeHashes, "','"))
 			queryBuf.WriteString(notInQuery) // nolint: gosec
 		}
+
+		queryBuf.WriteString(" ORDER BY") // nolint: gosec
+		// Using standard SQL here bc of issues using : with prepared statements
 		if criteria.Reverse {
-			queryBuf.WriteString(" ORDER BY e.timestamp DESC, e.id DESC") // nolint: gosec
+			queryBuf.WriteString(" CAST(e.log_payload->>'BlockNumber' as integer) DESC,") // nolint: gosec
+			queryBuf.WriteString(" CAST(e.log_payload->>'Index' as integer) DESC")        // nolint: gosec
 		} else {
-			queryBuf.WriteString(" ORDER BY e.timestamp, e.id") // nolint: gosec
+			queryBuf.WriteString(" CAST(e.log_payload->>'BlockNumber' as integer),") // nolint: gosec
+			queryBuf.WriteString(" CAST(e.log_payload->>'Index' as integer)")        // nolint: gosec
 		}
+
 		if criteria.Offset > 0 {
 			queryBuf.WriteString(" OFFSET :offset") // nolint: gosec
 		}

--- a/pkg/persistence/postgrespersister_test.go
+++ b/pkg/persistence/postgrespersister_test.go
@@ -121,7 +121,7 @@ var (
 			TxHash:      common.Hash{},
 			TxIndex:     4,
 			BlockHash:   common.Hash{},
-			Index:       2,
+			Index:       3,
 			Removed:     false,
 		},
 	}
@@ -1139,8 +1139,10 @@ func TestRetrieveEvents(t *testing.T) {
 	if len(events) != 1 {
 		t.Errorf("Should have seen only 1 event: %v", len(events))
 	}
-	if events[0].EventType() != civilEventsFromContract[0].EventType() {
-		t.Errorf("Should have seen the type of the oldest event: err: %v", err)
+	// Application
+	if events[0].EventType() != civilEventsFromContract[1].EventType() {
+		t.Errorf("Should have seen the type of the oldest event: %+v == %+v",
+			events[0].EventType(), civilEventsFromContract[1].EventType())
 	}
 
 	events, err = persister.retrieveEventsFromTable(eventTestTableName, &model.RetrieveEventsCriteria{
@@ -1205,14 +1207,15 @@ func TestRetrieveEvents(t *testing.T) {
 	if len(events) != 3 {
 		t.Errorf("Should have seen only 2 event: %v", len(events))
 	}
-	if events[0].Hash() != civilEventsFromContract[0].Hash() {
-		t.Errorf("Should have seen the type of the most recent event: err: %v", err)
+	// Check to see if the proper sorting occurred
+	if events[0].Hash() != civilEventsFromContract[1].Hash() {
+		t.Errorf("Should have seen the type of the second event")
 	}
-	if events[1].Hash() != civilEventsFromContract[1].Hash() {
-		t.Errorf("Should have seen the type of the most recent event: err: %v", err)
+	if events[1].Hash() != civilEventsFromContract[2].Hash() {
+		t.Errorf("Should have seen the type of the third event")
 	}
-	if events[2].Hash() != civilEventsFromContract[2].Hash() {
-		t.Errorf("Should have seen the type of the most recent event: err: %v", err)
+	if events[2].Hash() != civilEventsFromContract[0].Hash() {
+		t.Errorf("Should have seen the type of the first event")
 	}
 
 	events, err = persister.retrieveEventsFromTable(eventTestTableName, &model.RetrieveEventsCriteria{


### PR DESCRIPTION
We sorted by block timestamp and internal ID which *sometimes* goes awry depending on when we receive events on the watchers from Infura. We should sort by block number and index to ensure no matter what order we receive events into the crawler, it is correct as specified by the log data when we query.  This should fix some random ordering issues we have seen, which are mostly on events within the same block.

We could keep the sort by timestamp since it is pulled from the block data, but sorting instead by block number seems reasonable and more stable.

**TODO** 
Update the processor to use the new sorting.