### PR TITLE
Fix Makefile to Generate All Civil Code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ lint: check-go-env ## Runs linting.
 	@golangci-lint run ./...
 
 .PHONY: generate-civil
-generate: generate-contracts generate-civil-watchers generate-civil-filterers generate-civil-common generate-civil-handler-lists ## Runs all the civil code generation
+generate-civil: generate-civil-watchers generate-civil-filterers generate-civil-common generate-civil-handler-lists ## Runs all the civil code generation
 
 .PHONY: generate-civil-watchers
 generate-civil-watchers: check-go-env ## Runs watchergen to generate contract Watch* wrapper code for Civil.


### PR DESCRIPTION
`generate` cmd was out of date, updates contracts moving to `go-common`