### PR TITLE
Increase Websocket Ping Interval

### DIFF
--- a/pkg/eventcollector/eventcollector.go
+++ b/pkg/eventcollector/eventcollector.go
@@ -26,7 +26,7 @@ import (
 const (
 	blockHeaderExpirySecs = 60 * 5 // 5 mins
 
-	wsPingDelaySecs = 10 // 10 secs
+	wsPingDelaySecs = 60 * 2 // 2 min
 
 	defaultPollingIntervalSecs = 60 // 60 secs
 )


### PR DESCRIPTION
* Reduces number of Infura calls used.
* Test to see if this even helps at all in keeping subscriptions open or whether it is still an issue.  